### PR TITLE
🔧 Add consistent-type-imports rule to .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,5 +15,7 @@
     "sourceType": "module"
   },
   "plugins": ["@typescript-eslint"],
-  "rules": {}
+  "rules": {
+    "@typescript-eslint/consistent-type-imports": "error"
+  }
 }


### PR DESCRIPTION
In order to enforce correct imports for types, we add the following rule to our `.eslintrc.json`
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md